### PR TITLE
Feature/22 refactoring dtos frontend

### DIFF
--- a/library-client/src/components/BookDetail.vue
+++ b/library-client/src/components/BookDetail.vue
@@ -85,7 +85,7 @@
                   <div class="user-avatar">
                     <ion-icon :icon="avatarIcon" />
                   </div>
-                  <span class="user-id">User {{ rev.userId }}</span>
+                  <span class="user-name">{{ rev.userFullName }}</span>
                   <div class="user-stars">
                     <ion-icon
                         v-for="i in rev.rating"
@@ -363,7 +363,7 @@ const ratingPercent = computed(() => {
   color: #666;
 }
 
-.user-id {
+.user-name {
   font-weight: 600;
   font-size: 0.9rem;
 }

--- a/library-client/src/components/BookDetail.vue
+++ b/library-client/src/components/BookDetail.vue
@@ -144,7 +144,7 @@ import {
 } from '@ionic/vue'
 import { onMounted, ref, computed } from 'vue'
 import { bookService } from '@/services/bookService'
-import type { RatingDTO } from '@/DTOs/ratingDTO'
+import type { Rating } from '@/models/rating'
 import {
   chevronDownOutline,
   chevronUpOutline,
@@ -154,11 +154,11 @@ import {
   personCircleOutline
 } from 'ionicons/icons'
 import defaultCover from '../../assets/default_book_cover.jpg'
-import {BookDTO} from "@/DTOs/bookDTO";
+import {Book} from "@/models/book";
 import {useNavigation} from "@/services/navigationService";
 
-const book = ref<BookDTO>()
-const ratings = ref<RatingDTO[]>([])
+const book = ref<Book>()
+const ratings = ref<Rating[]>([])
 const expanded = ref(false)
 
 const chevronDown = chevronDownOutline

--- a/library-client/src/components/Books.vue
+++ b/library-client/src/components/Books.vue
@@ -63,15 +63,15 @@ import {
 } from "@ionic/vue";
 import defaultCover from '../../assets/default_book_cover.jpg'
 import {onMounted, ref} from "vue";
-import {LibraryDTO} from "@/DTOs/libraryDTO";
+import {Library} from "@/models/library";
 import {libraryService} from "@/services/librariesService";
-import {BookDTO} from "@/DTOs/bookDTO";
+import {Book} from "@/models/book";
 import {useNavigation} from "@/services/navigationService";
 const { navigateTo } = useNavigation()
 const { setIdToUrl } = useNavigation()
 const { getIdFromUrl } = useNavigation()
-const libraries = ref<LibraryDTO[]>([])
-const books = ref<BookDTO[]>([])
+const libraries = ref<Library[]>([])
+const books = ref<Book[]>([])
 const selectedLibrary = ref<number | null>(null)
 
 onMounted(async () => {

--- a/library-client/src/models/book.ts
+++ b/library-client/src/models/book.ts
@@ -1,4 +1,4 @@
-export interface BookDTO {
+export interface Book {
     id: number
     libraryId: number
     author: string

--- a/library-client/src/models/library.ts
+++ b/library-client/src/models/library.ts
@@ -1,4 +1,4 @@
-export interface LibraryDTO {
+export interface Library {
     id: number
     name: string
     address: string

--- a/library-client/src/models/rating.ts
+++ b/library-client/src/models/rating.ts
@@ -1,4 +1,4 @@
-export interface RatingDTO {
+export interface Rating {
     id: number
     bookId: number
     userId: number

--- a/library-client/src/models/rating.ts
+++ b/library-client/src/models/rating.ts
@@ -2,6 +2,7 @@ export interface Rating {
     id: number
     bookId: number
     userId: number
+    userFullName: string
     rating: number
     comment: string
 }

--- a/library-client/src/services/bookService.ts
+++ b/library-client/src/services/bookService.ts
@@ -1,18 +1,18 @@
 import axios from 'axios';
-import {RatingDTO} from "@/DTOs/ratingDTO";
-import {BookDTO} from "@/DTOs/bookDTO";
+import {Rating} from "@/models/rating";
+import {Book} from "@/models/book";
 
 const API_URL = 'http://localhost:8080/library-system/v1/books';
 
 export const bookService = {
 
-    async getBookDetails(id: number): Promise<BookDTO> {
-        const response = await axios.get<BookDTO>(`${API_URL}/${id}`);
+    async getBookDetails(id: number): Promise<Book> {
+        const response = await axios.get<Book>(`${API_URL}/${id}`);
         return response.data;
     },
 
-    async getBooksOfLibrary(bookId: number): Promise<RatingDTO[]> {
-        const response = await axios.get<RatingDTO[]>(`${API_URL}/${bookId}/ratings`);
+    async getBooksOfLibrary(bookId: number): Promise<Rating[]> {
+        const response = await axios.get<Rating[]>(`${API_URL}/${bookId}/ratings`);
         return response.data;
     },
 };

--- a/library-client/src/services/librariesService.ts
+++ b/library-client/src/services/librariesService.ts
@@ -1,17 +1,17 @@
 import axios from 'axios';
-import {LibraryDTO} from "@/DTOs/libraryDTO";
-import {BookDTO} from "@/DTOs/bookDTO";
+import {Library} from "@/models/library";
+import {Book} from "@/models/book";
 
 const API_URL = 'http://localhost:8080/library-system/v1/libraries';
 
 export const libraryService = {
-    async getLibraries(): Promise<LibraryDTO[]> {
-        const response = await axios.get<LibraryDTO[]>(API_URL);
+    async getLibraries(): Promise<Library[]> {
+        const response = await axios.get<Library[]>(API_URL);
         return response.data;
     },
 
-    async getBooksOfLibrary(libraryId: number): Promise<BookDTO[]> {
-        const response = await axios.get<BookDTO[]>(`${API_URL}/${libraryId}/books`);
+    async getBooksOfLibrary(libraryId: number): Promise<Book[]> {
+        const response = await axios.get<Book[]>(`${API_URL}/${libraryId}/books`);
         return response.data;
     },
 };

--- a/library-client/src/stores/bookStore.ts
+++ b/library-client/src/stores/bookStore.ts
@@ -1,9 +1,9 @@
 import { defineStore } from 'pinia'
-import type { BookDTO } from '@/DTOs/bookDTO'
+import type { Book } from '@/models/book'
 
 export const useBookStore = defineStore('book', {
-    state: () => ({ current: null as BookDTO | null }),
+    state: () => ({ current: null as Book | null }),
     actions: {
-        select(book: BookDTO) { this.current = book }
+        select(book: Book) { this.current = book }
     }
 })


### PR DESCRIPTION
refactoring
update and rename DTOs in frontend
DTOs without suffix DTO - only objects
rename folder to "models"

Objects affected:
bookDTO -> book
libraryDTO -> library
ratingsDTO -> ratings, add userFullName

logic:
display userFullName in ratings